### PR TITLE
Raw value getters updated to be functions. Modifiers and Normalizers …

### DIFF
--- a/packages/.vscode/cSpell.json
+++ b/packages/.vscode/cSpell.json
@@ -10,6 +10,7 @@
         "Unmount",
         "Validators",
         "deduped",
+        "recordified",
         "recordify",
         "simplr",
         "tslib",

--- a/packages/.vscode/cSpell.json
+++ b/packages/.vscode/cSpell.json
@@ -9,6 +9,7 @@
         "Normalizers",
         "Unmount",
         "Validators",
+        "deduped",
         "recordify",
         "simplr",
         "tslib",

--- a/packages/react-forms-dom/src/components/checkbox.tsx
+++ b/packages/react-forms-dom/src/components/checkbox.tsx
@@ -49,9 +49,9 @@ export class CheckBox extends BaseDomField<CheckBoxProps, BaseDomFieldState, HTM
         }
     }
 
-    protected get RawDefaultValue(): boolean {
-        if (this.props.defaultValue != null) {
-            return this.props.defaultValue;
+    protected GetRawDefaultValue(props: CheckBoxProps): boolean {
+        if (props.defaultValue != null) {
+            return props.defaultValue;
         }
         return false;
     }

--- a/packages/react-forms-dom/src/components/email.tsx
+++ b/packages/react-forms-dom/src/components/email.tsx
@@ -46,9 +46,9 @@ export class Email extends BaseDomField<EmailProps, BaseDomFieldState, HTMLInput
         }
     }
 
-    protected get RawDefaultValue(): string {
-        if (this.props.defaultValue != null) {
-            return this.props.defaultValue;
+    protected GetRawDefaultValue(props: EmailProps): string {
+        if (props.defaultValue != null) {
+            return props.defaultValue;
         }
         return "";
     }

--- a/packages/react-forms-dom/src/components/hidden.tsx
+++ b/packages/react-forms-dom/src/components/hidden.tsx
@@ -12,8 +12,8 @@ export class Hidden extends BaseField<HiddenProps, BaseFieldState> {
         return true;
     }
 
-    protected get RawDefaultValue(): FieldValue {
-        return this.props.defaultValue;
+    protected GetRawDefaultValue(props: HiddenProps): FieldValue {
+        return props.defaultValue;
     }
 
     public render(): null {

--- a/packages/react-forms-dom/src/components/number.tsx
+++ b/packages/react-forms-dom/src/components/number.tsx
@@ -51,9 +51,9 @@ export class Number extends BaseDomField<NumberProps, BaseDomFieldState> {
         }
     }
 
-    protected get RawDefaultValue(): string {
-        if (this.props.defaultValue != null) {
-            return this.props.defaultValue;
+    protected GetRawDefaultValue(props: NumberProps): string {
+        if (props.defaultValue != null) {
+            return props.defaultValue;
         }
         return "";
     }

--- a/packages/react-forms-dom/src/components/password.tsx
+++ b/packages/react-forms-dom/src/components/password.tsx
@@ -46,9 +46,9 @@ export class Password extends BaseDomField<PasswordProps, BaseDomFieldState> {
         }
     }
 
-    protected get RawDefaultValue(): string {
-        if (this.props.defaultValue != null) {
-            return this.props.defaultValue;
+    protected GetRawDefaultValue(props: PasswordProps): string {
+        if (props.defaultValue != null) {
+            return props.defaultValue;
         }
         return "";
     }

--- a/packages/react-forms-dom/src/components/radio-group.tsx
+++ b/packages/react-forms-dom/src/components/radio-group.tsx
@@ -45,9 +45,9 @@ export class RadioGroup extends BaseDomField<RadioGroupProps, BaseFieldState> {
         };
     }
 
-    protected get RawDefaultValue(): React.ReactText {
-        if (this.props.defaultValue != null) {
-            return this.props.defaultValue;
+    protected GetRawDefaultValue(props: RadioGroupProps): React.ReactText {
+        if (props.defaultValue != null) {
+            return props.defaultValue;
         }
 
         return "";

--- a/packages/react-forms-dom/src/components/search.tsx
+++ b/packages/react-forms-dom/src/components/search.tsx
@@ -47,9 +47,9 @@ export class Search extends BaseDomField<SearchProps, BaseDomFieldState> {
         }
     }
 
-    protected get RawDefaultValue(): string {
-        if (this.props.defaultValue != null) {
-            return this.props.defaultValue;
+    protected GetRawDefaultValue(props: SearchProps): string {
+        if (props.defaultValue != null) {
+            return props.defaultValue;
         }
         return "";
     }

--- a/packages/react-forms-dom/src/components/select.tsx
+++ b/packages/react-forms-dom/src/components/select.tsx
@@ -30,15 +30,15 @@ export interface SelectState extends BaseDomFieldState {
 }
 
 export class Select extends BaseDomField<SelectProps, SelectState> {
-    protected get RawInitialValue(): SelectValue | undefined {
-        if (this.props.multiple ||
-            this.props.initialValue != null) {
-            return this.props.initialValue;
+    protected GetRawInitialValue(props: SelectProps): SelectValue | undefined {
+        if (props.multiple ||
+            props.initialValue != null) {
+            return props.initialValue;
         }
         // If select does not have multiple options, then we need to get the first option value.
         const options = React
             .Children
-            .toArray(this.props.children)
+            .toArray(props.children)
             .filter((x: JSX.Element) => x.type != null && x.type === "option");
 
         if (options.length === 0) {
@@ -98,11 +98,11 @@ export class Select extends BaseDomField<SelectProps, SelectState> {
         }
     }
 
-    protected get RawDefaultValue(): SelectValue {
-        if (this.props.defaultValue != null) {
-            return this.props.defaultValue;
+    protected GetRawDefaultValue(props: SelectProps): SelectValue {
+        if (props.defaultValue != null) {
+            return props.defaultValue;
         }
-        return (this.props.multiple) ? [] : "";
+        return (props.multiple) ? [] : "";
     }
 
     protected get Value(): SelectValue {
@@ -110,7 +110,7 @@ export class Select extends BaseDomField<SelectProps, SelectState> {
             return this.state.RenderValue;
         }
 
-        return this.RawDefaultValue;
+        return this.GetRawDefaultValue(this.props);
     }
 
     public renderField(): JSX.Element {

--- a/packages/react-forms-dom/src/components/text.tsx
+++ b/packages/react-forms-dom/src/components/text.tsx
@@ -55,9 +55,9 @@ export class Text extends BaseDomField<TextProps, BaseDomFieldState, HTMLInputEl
         }
     }
 
-    protected get RawDefaultValue(): string {
-        if (this.props.defaultValue != null) {
-            return this.props.defaultValue;
+    protected GetRawDefaultValue(props: TextProps): string {
+        if (props.defaultValue != null) {
+            return props.defaultValue;
         }
 
         return "";

--- a/packages/react-forms-dom/src/components/textarea.tsx
+++ b/packages/react-forms-dom/src/components/textarea.tsx
@@ -56,9 +56,9 @@ export class TextArea extends BaseDomField<TextAreaProps, BaseDomFieldState> {
         }
     }
 
-    protected get RawDefaultValue(): string {
-        if (this.props.defaultValue != null) {
-            return this.props.defaultValue;
+    protected GetRawDefaultValue(props: TextAreaProps): string {
+        if (props.defaultValue != null) {
+            return props.defaultValue;
         }
         return "";
     }

--- a/packages/react-forms-validation/src/contracts.ts
+++ b/packages/react-forms-validation/src/contracts.ts
@@ -5,7 +5,7 @@ export interface Validator {
     Validate(value: any): ValidationResult;
 }
 
-export type ValidationError<TTemplateFunc = Function> = string | FormError | TTemplateFunc;
+export type ValidationError<TTemplateFunc = (...args: any[]) => void> = string | FormError | TTemplateFunc;
 
 export type ValidationFormErrorTemplate = (formStore: FormStore) => ValidationError;
 export type ValidationFieldErrorTemplate = (fieldId: string, formStore: FormStore) => ValidationError;

--- a/packages/react-forms-validation/src/utils/validation.ts
+++ b/packages/react-forms-validation/src/utils/validation.ts
@@ -28,7 +28,7 @@ export async function ValidateValue(
     components: JSX.Element[],
     value: any,
     validatorTypeFunctionName: string,
-    errorProccessor: (error: ValidationResult) => ValidationResult
+    errorProcessor: (error: ValidationResult) => ValidationResult
 ): Promise<void> {
     const validators = components.filter(x => IsComponentOfType(x, validatorTypeFunctionName));
     const renderedValidators = RenderComponents<Validator>(validators);
@@ -47,7 +47,7 @@ export async function ValidateValue(
             validationError = validationResult;
         }
 
-        const builtError = errorProccessor(validationError);
+        const builtError = errorProcessor(validationError);
         const error = ConstructFormError(builtError, FormErrorOrigin.Validation);
         if (error !== undefined) {
             throw error;

--- a/packages/react-forms/__tests__/test-components/test-field.tsx
+++ b/packages/react-forms/__tests__/test-components/test-field.tsx
@@ -21,17 +21,17 @@ export class MyTestField extends BaseField<MyFieldProps, BaseFieldState> {
         this.OnValueChange(target.value);
     }
 
-    protected get RawInitialValue(): FieldValue {
+    protected GetRawInitialValue(props: MyFieldProps): FieldValue {
         return "";
     }
 
-    protected get RawValue(): FieldValue {
+    protected GetRawValue(props: MyFieldProps): FieldValue {
         return "";
     }
 
-    protected get RawDefaultValue(): FieldValue {
-        if (this.props.defaultValue != null) {
-            return this.props.defaultValue;
+    protected GetRawDefaultValue(props: MyFieldProps): FieldValue {
+        if (props.defaultValue != null) {
+            return props.defaultValue;
         }
         return "";
     }

--- a/packages/react-forms/src/abstractions/base-field.ts
+++ b/packages/react-forms/src/abstractions/base-field.ts
@@ -16,14 +16,14 @@ export abstract class BaseField<TProps extends FieldProps, TState extends BaseFi
         }
     }
 
-    protected abstract get RawDefaultValue(): FieldValue;
+    protected abstract GetRawDefaultValue(props: TProps): FieldValue;
 
-    protected get RawInitialValue(): FieldValue {
-        return this.props.initialValue;
+    protected GetRawInitialValue(props: TProps): FieldValue {
+        return props.initialValue;
     }
 
-    protected get RawValue(): FieldValue {
-        return this.props.value;
+    protected GetRawValue(props: TProps): FieldValue {
+        return props.value;
     }
 
     protected get IsControlled(): boolean {
@@ -46,7 +46,7 @@ export abstract class BaseField<TProps extends FieldProps, TState extends BaseFi
         }
 
         // Return default value
-        return this.RawDefaultValue;
+        return this.GetRawDefaultValue(this.props);
     }
 
     protected get Disabled(): boolean | undefined {

--- a/packages/react-forms/src/abstractions/base-fields-array.ts
+++ b/packages/react-forms/src/abstractions/base-fields-array.ts
@@ -34,7 +34,22 @@ export class BaseFieldsArray<TProps extends FieldsArrayProps,
     };
 
     protected get FormId(): string {
-        return this.context.FormId || this.props.formId;
+        // Check for whether FieldsArray is being used inside of a form.
+        const props: FieldsArrayProps = this.props;
+
+        if (this.context.FormId != null) {
+            // If both context and props have form id defined
+            if (props.formId != null) {
+                throw new Error("@simplr/react-forms: formId prop is defined, but FieldsArray is already inside a Form.");
+            }
+
+            return this.context.FormId;
+        }
+        if (props.formId != null) {
+            return props.formId;
+        }
+
+        throw new Error("@simplr/react-forms: FieldsArray must be used inside a Form component or formId must be defined.");
     }
 
     protected get FormStore(): FormStore {
@@ -57,7 +72,7 @@ export class BaseFieldsArray<TProps extends FieldsArrayProps,
 
     public componentWillMount(): void {
         if (this.FormId == null) {
-            throw new Error("@simplr/react-forms: FieldsArray must be used inside a Form component or formId must be defined.");
+            // Never goes in here, because an Error is thrown inside this.FormId if it's not valid.
         }
 
         this.FieldsArrayId = FormStoreHelpers.GetFieldsArrayId(this.props.name, this.props.arrayKey, this.context.FieldsGroupId);

--- a/packages/react-forms/src/abstractions/core-field.ts
+++ b/packages/react-forms/src/abstractions/core-field.ts
@@ -384,7 +384,10 @@ export abstract class CoreField<TProps extends CoreFieldProps, TState extends Co
             this.GetRawInitialValue(this.props),
             this.ProcessValueBeforeStore.bind(this)
         );
-        const value = this.processedOrEmptyModifierValue(this.GetRawValue(this.props), this.ProcessValueBeforeStore.bind(this));
+        const value = this.processedOrEmptyModifierValue(
+            this.GetRawValue(this.props),
+            this.ProcessValueBeforeStore.bind(this)
+        );
 
         // If field does not exist
         if (!formHasField) {

--- a/packages/react-forms/src/contracts/value.ts
+++ b/packages/react-forms/src/contracts/value.ts
@@ -1,13 +1,16 @@
 import { FieldValue } from "./field";
+import { TypedRecord } from "typed-immutable-record";
 
 export interface ModifierValue {
     Value: FieldValue;
     TransitionalValue?: FieldValue;
 }
 
+export interface ModifierValueRecord extends TypedRecord<ModifierValueRecord>, ModifierValue { }
+
 export interface Modifier {
     Format(value: FieldValue): FieldValue;
-    Parse(value: ModifierValue): ModifierValue;
+    Parse(value: ModifierValueRecord): ModifierValueRecord;
 }
 
 export interface Normalizer {

--- a/packages/react-forms/src/modifiers/base-modifier.ts
+++ b/packages/react-forms/src/modifiers/base-modifier.ts
@@ -1,18 +1,27 @@
 import * as React from "react";
+import { recordify, TypedRecord } from "typed-immutable-record";
 import {
     Modifier,
     ModifierValue
 } from "../contracts/value";
 import { FieldValue } from "../contracts/field";
-import { ValueOfType } from "../utils/value-helpers";
+import { ModifierValueRecord } from "../contracts/value";
+import { ValueOfType, RecordifyModifierValue } from "../utils/value-helpers";
 
 export abstract class BaseModifier<TProps, TState> extends React.Component<TProps, TState> implements Modifier {
-    // Indentifier function
+    // Identifier function
     // tslint:disable-next-line:no-empty
     public static SimplrFormsCoreModifier(): void { }
+
     public abstract Format(value: FieldValue): FieldValue;
-    public abstract Parse(value: ModifierValue): ModifierValue;
+
+    public abstract Parse(value: ModifierValueRecord): ModifierValueRecord;
+
     public render(): null {
         return null;
+    }
+
+    protected Recordify<TValue extends ModifierValue>(value: TValue): ModifierValueRecord {
+        return RecordifyModifierValue(value);
     }
 }

--- a/packages/react-forms/src/modifiers/base-modifier.ts
+++ b/packages/react-forms/src/modifiers/base-modifier.ts
@@ -21,6 +21,10 @@ export abstract class BaseModifier<TProps, TState> extends React.Component<TProp
         return null;
     }
 
+    /**
+     * Proxy to value helpers RecordifyModifierValue method.
+     * @param value Value to be recordified
+     */
     protected Recordify<TValue extends ModifierValue>(value: TValue): ModifierValueRecord {
         return RecordifyModifierValue(value);
     }

--- a/packages/react-forms/src/modifiers/string-to-decimal.ts
+++ b/packages/react-forms/src/modifiers/string-to-decimal.ts
@@ -1,7 +1,7 @@
 import { FieldValue } from "../contracts/field";
 import { ValueOfType } from "../utils/value-helpers";
 import { BaseModifier } from "./base-modifier";
-import { ModifierValue } from "../contracts/value";
+import { ModifierValueRecord } from "../contracts/value";
 
 export interface StringToDecimalProps {
     delimiter?: string;
@@ -30,14 +30,14 @@ export class StringToDecimalModifier extends BaseModifier<StringToDecimalProps, 
         return EMPTY_VALUE;
     }
 
-    public Parse(modifierValue: ModifierValue): ModifierValue {
+    public Parse(modifierValue: ModifierValueRecord): ModifierValueRecord {
         let value = modifierValue.TransitionalValue != null ? modifierValue.TransitionalValue : modifierValue.Value;
 
         if (value.length === 0) {
-            return {
+            return this.Recordify({
                 Value: 0,
                 TransitionalValue: ""
-            };
+            });
         }
         if (ValueOfType<string>(modifierValue, StringToDecimalModifier.name, "object")) {
             let negative = false;
@@ -47,10 +47,10 @@ export class StringToDecimalModifier extends BaseModifier<StringToDecimalProps, 
 
                 // If there is only a minus sign
                 if (value.length === 0) {
-                    return {
+                    return this.Recordify({
                         Value: 0,
                         TransitionalValue: "-"
-                    };
+                    });
                 }
             }
 
@@ -93,14 +93,14 @@ export class StringToDecimalModifier extends BaseModifier<StringToDecimalProps, 
             const delimiterFixed = transitionalValue.replace(delimiter, ".");
             const numValue = Number(delimiterFixed);
 
-            return {
+            return this.Recordify({
                 Value: numValue,
                 TransitionalValue: transitionalValue !== numValue.toString() ? transitionalValue : undefined
-            };
+            });
         }
-        return {
+        return this.Recordify({
             Value: 0
-        };
+        });
     }
 
     protected TrimLeft(value: string, symbol: string): string {

--- a/packages/react-forms/src/modifiers/string-to-decimal.ts
+++ b/packages/react-forms/src/modifiers/string-to-decimal.ts
@@ -39,67 +39,69 @@ export class StringToDecimalModifier extends BaseModifier<StringToDecimalProps, 
                 TransitionalValue: ""
             });
         }
-        if (ValueOfType<string>(modifierValue, StringToDecimalModifier.name, "object")) {
-            let negative = false;
-            if (value.substr(0, 1) === "-") {
-                negative = true;
-                value = value.substr(1);
 
-                // If there is only a minus sign
-                if (value.length === 0) {
-                    return this.Recordify({
-                        Value: 0,
-                        TransitionalValue: "-"
-                    });
-                }
-            }
-
-            // Non-undefined because of defaultProps
-            const delimiter = this.props.delimiter!;
-
-            const leadingMinus = negative ? "-" : "";
-
-            // Include delimiter in regex if precision is non-zero
-            const regexPattern = this.props.precision === 0 ?
-                `[^0-9]+` :
-                `[^0-9\\${delimiter}]+`;
-
-            const regex = new RegExp(regexPattern, "g");
-            const extractedValue: string = this.LeaveOnlyFirstDelimiter(
-                value.replace(regex, ""),
-                delimiter);
-
-            const firstCharWasZero = extractedValue.substr(0, 1) === "0";
-
-            let transitionalValue = this.TrimLeft(extractedValue, "0");
-
-            // Add leading zero, if fraction is being entered without leading zero
-            const leadingZeroForFractionShortcut = transitionalValue.substr(0, 1) === this.props.delimiter;
-            const leadingZeroForFraction = firstCharWasZero &&
-                (transitionalValue.substr(1, 1) === this.props.delimiter || transitionalValue.length === 0);
-
-            if (leadingZeroForFractionShortcut || leadingZeroForFraction) {
-                transitionalValue = "0" + transitionalValue;
-            }
-
-            if (this.props.precision != null) {
-                const delimiterIndex = transitionalValue.indexOf(delimiter);
-                if (delimiterIndex !== -1) {
-                    transitionalValue = transitionalValue.substr(0, delimiterIndex + this.props.precision + 1);
-                }
-            }
-
-            transitionalValue = leadingMinus + transitionalValue;
-            const delimiterFixed = transitionalValue.replace(delimiter, ".");
-            const numValue = Number(delimiterFixed);
-
+        if (!ValueOfType<string>(value, StringToDecimalModifier.name, "string")) {
             return this.Recordify({
-                Value: numValue,
-                TransitionalValue: transitionalValue !== numValue.toString() ? transitionalValue : undefined
+                Value: 0
             });
         }
+
+        let negative = false;
+        if (value.substr(0, 1) === "-") {
+            negative = true;
+            value = value.substr(1);
+
+            // If there is only a minus sign
+            if (value.length === 0) {
+                return this.Recordify({
+                    Value: 0,
+                    TransitionalValue: "-"
+                });
+            }
+        }
+
+        // Non-undefined because of defaultProps
+        const delimiter = this.props.delimiter!;
+
+        const leadingMinus = negative ? "-" : "";
+
+        // Include delimiter in regex if precision is non-zero
+        const regexPattern = this.props.precision === 0 ?
+            `[^0-9]+` :
+            `[^0-9\\${delimiter}]+`;
+
+        const regex = new RegExp(regexPattern, "g");
+        const extractedValue: string = this.LeaveOnlyFirstDelimiter(
+            value.replace(regex, ""),
+            delimiter);
+
+        const firstCharWasZero = extractedValue.substr(0, 1) === "0";
+
+        let transitionalValue = this.TrimLeft(extractedValue, "0");
+
+        // Add leading zero, if fraction is being entered without leading zero
+        const leadingZeroForFractionShortcut = transitionalValue.substr(0, 1) === this.props.delimiter;
+        const leadingZeroForFraction = firstCharWasZero &&
+            (transitionalValue.substr(1, 1) === this.props.delimiter || transitionalValue.length === 0);
+
+        if (leadingZeroForFractionShortcut || leadingZeroForFraction) {
+            transitionalValue = "0" + transitionalValue;
+        }
+
+        if (this.props.precision != null) {
+            const delimiterIndex = transitionalValue.indexOf(delimiter);
+            if (delimiterIndex !== -1) {
+                transitionalValue = transitionalValue.substr(0, delimiterIndex + this.props.precision + 1);
+            }
+        }
+
+        transitionalValue = leadingMinus + transitionalValue;
+        const delimiterFixed = transitionalValue.replace(delimiter, ".");
+        const numValue = Number(delimiterFixed);
+
         return this.Recordify({
-            Value: 0
+            Value: numValue,
+            TransitionalValue: transitionalValue !== numValue.toString() ? transitionalValue : undefined
         });
     }
 

--- a/packages/react-forms/tools/webpack.config.ts
+++ b/packages/react-forms/tools/webpack.config.ts
@@ -15,7 +15,7 @@ for (const key in packageJson.dependencies) {
 
 const externalsResolver = [
     externals,
-    function (context: string, request: string, callback: Function) {
+    (context: string, request: string, callback: (...args: any[]) => void): void => {
         const directoriesToTest = [
             "abstractions",
             "actions",
@@ -42,7 +42,7 @@ const externalsResolver = [
                 resolvedPath.indexOf(path.join(__dirname, `src/${passingTest.directory}`)) !== -1;
 
             if (shouldReplaceWithCustomResolve) {
-                let customResolve = `./${passingTest.directory}`;
+                const customResolve = `./${passingTest.directory}`;
                 callback(null, customResolve);
                 return;
             }


### PR DESCRIPTION
…now must use immutable values.

Because we need to check values coming from `props` not only during field registration, but also during `componentWillReceiveProps` lifecycle event, all of the `get Raw*Value` getters had to be updated to `GetRaw*Value(props: TProps)` methods.

Also, for the big change it was, we added another one:
Modifiers and Normalizers now get and return immutable values. There may be additional checks added later on in the pipeline.

Additionally, `FormId` is now resolved either from `context.FormId` or from `props.formId` in fields.