### PR TITLE
Hotfix/submit handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "rush-tools": "ts-node ./tools/rush-tools.ts"
   },
   "devDependencies": {
-    "@microsoft/rush": "^3.0.11",
-    "@microsoft/rush-lib": "^3.0.11",
+    "@microsoft/rush": "3.0.11",
+    "@microsoft/rush-lib": "3.0.11",
     "@microsoft/ts-command-line": "^2.0.2",
     "@types/semver": "^5.3.32",
     "@types/shelljs": "^0.7.2",

--- a/packages/react-forms-dom/src/components/form.tsx
+++ b/packages/react-forms-dom/src/components/form.tsx
@@ -27,7 +27,11 @@ export class Form extends BaseForm<FormProps, {}> {
         this.Element = element;
         if (this.FormStore != null && element != null) {
             this.FormStore.SetFormSubmitCallback(() => {
-                element.dispatchEvent(new Event("submit"));
+                const eventSubmit = document.createEvent("Event");
+                eventSubmit.initEvent("submit", true, true);
+                eventSubmit.preventDefault();
+
+                element.dispatchEvent(eventSubmit);
             });
         }
     }
@@ -38,8 +42,8 @@ export class Form extends BaseForm<FormProps, {}> {
     };
 
     protected FormSubmitHandler = (event: React.FormEvent<HTMLFormElement>): void => {
+        event.preventDefault();
         if (this.props.preventSubmitDefaultAndPropagation) {
-            event.preventDefault();
             event.stopPropagation();
         }
         if (!this.ShouldFormSubmit()) {

--- a/packages/react-forms-dom/src/components/form.tsx
+++ b/packages/react-forms-dom/src/components/form.tsx
@@ -38,12 +38,12 @@ export class Form extends BaseForm<FormProps, {}> {
 
     public static defaultProps: FormProps = {
         ...BaseForm.defaultProps,
-        preventSubmitDefaultAndPropagation: true
+        preventSubmitPropagation: true
     };
 
     protected FormSubmitHandler = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault();
-        if (this.props.preventSubmitDefaultAndPropagation) {
+        if (this.props.preventSubmitPropagation) {
             event.stopPropagation();
         }
         if (!this.ShouldFormSubmit()) {
@@ -68,7 +68,7 @@ export class Form extends BaseForm<FormProps, {}> {
     protected GetHTMLProps(props: BaseFormProps): {} {
         const {
             formId,
-            preventSubmitDefaultAndPropagation,
+            preventSubmitPropagation,
             template,
             formStore,
             destroyOnUnmount,

--- a/packages/react-forms-dom/src/contracts/form.ts
+++ b/packages/react-forms-dom/src/contracts/form.ts
@@ -21,7 +21,7 @@ export type FormOnChangeInternalCallback = FieldOnChangeInternalCallback;
 
 export interface BaseFormProps extends CoreFormProps {
     onChange?: FormOnChangeCallback & FormOnChangeInternalCallback;
-    preventSubmitDefaultAndPropagation?: boolean;
+    preventSubmitPropagation?: boolean;
     template?: DomFieldTemplateCallback;
     errorClassName?: string;
     // tslint:disable-next-line:max-line-length


### PR DESCRIPTION
- Renamed form prop from `preventSubmitDefaultAndPropagation` to `preventSubmitPropagation`
- Fixed custom submit event dispatching in FireFox browser